### PR TITLE
Feature/MapContext

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import Map from './components/Map';
+import { MapProvider } from './context/MapContext';
 import { MapLayerOSM } from './lib/map-layers';
 
 const App = () => {
@@ -6,15 +7,17 @@ const App = () => {
     <main className="h-screen w-full">
       <h1>React GIS-OL - OpenLayers</h1>
       <div className="h-[800px] w-full">
-        <Map
-          layer={MapLayerOSM}
-          view={{
-            center: [149.069, -35.5],
-            zoom: 10,
-            minZoom: 0,
-            maxZoom: 28,
-          }}
-        />
+        <MapProvider>
+          <Map
+            layer={MapLayerOSM}
+            view={{
+              center: [149.069, -35.5],
+              zoom: 10,
+              minZoom: 0,
+              maxZoom: 28,
+            }}
+          />
+        </MapProvider>
       </div>
     </main>
   );

--- a/src/context/CurrentMapContext.tsx
+++ b/src/context/CurrentMapContext.tsx
@@ -1,0 +1,6 @@
+import { createContext } from 'react';
+
+import { type Map } from '../lib/openlayers';
+
+export type CurrentMapContextValue = { map?: Map };
+export const CurrentMapContext = createContext<CurrentMapContextValue>({ map: undefined });

--- a/src/context/MapContext.tsx
+++ b/src/context/MapContext.tsx
@@ -1,0 +1,17 @@
+import { createContext, useState } from 'react';
+
+import { type Map } from '../lib/openlayers';
+import { type SetState } from '../types/types';
+
+export type MapContextValue = {
+  map?: Map;
+  setMap: SetState<Map | undefined>;
+} | null;
+
+export const MapContext = createContext<MapContextValue>(null);
+
+export const MapProvider = ({ children }: { children: React.ReactNode }) => {
+  const [map, setMap] = useState<Map>();
+
+  return <MapContext.Provider value={{ map, setMap }}>{children}</MapContext.Provider>;
+};

--- a/src/hooks/useMap.tsx
+++ b/src/hooks/useMap.tsx
@@ -1,43 +1,11 @@
-import { useEffect, useRef, useState } from 'react';
+import { useContext } from 'react';
 
-import { Map as OlMap, useGeographic, View } from '../lib/openlayers';
-import { type MapLayer, type ViewOptions } from '../types/openlayers';
+import { CurrentMapContext } from '../context/CurrentMapContext';
+import { MapContext } from '../context/MapContext';
 
-export type UseMapProps = {
-  layer: MapLayer;
-  view?: ViewOptions;
-};
+export const useMap = () => {
+  const map = useContext(MapContext)?.map;
+  const currentMap = useContext(CurrentMapContext)?.map;
 
-export const useMap = ({ layer, view }: UseMapProps) => {
-  const mapRef = useRef<HTMLDivElement>(null);
-
-  const [map, setMap] = useState<OlMap>();
-
-  useEffect(() => {
-    //? This is not a react hook, this is from openlayers, safe to ignore
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useGeographic();
-
-    const olMap = new OlMap({
-      layers: layer.layer,
-      view: new View({
-        center: [0, 0],
-        zoom: 0,
-        ...view,
-      }),
-    });
-    olMap.setTarget(mapRef.current ?? '');
-    setMap(olMap);
-
-    return () => olMap.setTarget('');
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  useEffect(() => {
-    if (map) {
-      map.setLayers(layer.layer);
-    }
-  }, [map, layer]);
-
-  return { mapRef, map, setMap };
+  return { map: map, current: currentMap };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,14 @@
 export { default as Map } from './components/Map';
 export type * from './components/Map';
+
+export * from './context/MapContext';
+export type * from './context/MapContext';
+
 export * from './hooks/useMap';
 export type * from './hooks/useMap';
-export type * from './types/openlayers';
+
 export { MapLayerOSM } from './lib/map-layers';
 export type * from './lib/map-layers';
+
+export type * from './types/openlayers';
+export type * from './types/types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,9 @@ export type * from './components/Map';
 export * from './context/MapContext';
 export type * from './context/MapContext';
 
+export * from './context/CurrentMapContext';
+export type * from './context/CurrentMapContext';
+
 export * from './hooks/useMap';
 export type * from './hooks/useMap';
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,0 +1,1 @@
+export type SetState<T> = React.Dispatch<React.SetStateAction<T>>;


### PR DESCRIPTION
- feat: ✨ add MapContext (f3212e3)
   - Allows the map object to be accessed in components outside of `<Map/>` if wrapped in `<MapProvider/>`.
- feat: ✨ add CurrentMapContext (22f6f32)
   - Allows the current map object to be accessed inside (child) of `<Map/>`.
-  feat: ✨ move useMap logic into Map & change useMap to get context from MapContext & CurrentMapContext (2150b44)
   - Moved logic out of `useMap` into `<Map/>` & repurposed `useMap` to get `MapContext` or `CurrentMapContext`.
